### PR TITLE
Added `destroy` method for the `PinchZoom` instance

### DIFF
--- a/src/pinch-zoom.js
+++ b/src/pinch-zoom.js
@@ -666,7 +666,8 @@ var definePinchZoom = function () {
             var self = this;
             detectGestures(this.container, this);
 
-            window.addEventListener('resize', this.update.bind(this));
+            this.resizeHandler = this.update.bind(this)
+            window.addEventListener('resize', this.resizeHandler);
             Array.from(this.el.querySelectorAll('img')).forEach(function(imgEl) {
               imgEl.addEventListener('load', self.update.bind(self));
             });
@@ -759,7 +760,16 @@ var definePinchZoom = function () {
          */
         disable: function() {
           this.enabled = false;
+        },
+
+        /**
+         * Unmounts the zooming container and global event listeners
+         */
+        destroy: function () {
+          window.removeEventListener('resize', this.resizeHandler);
+          this.container.remove();
         }
+
     };
 
     var detectGestures = function (el, target) {


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/manuelstofer/pinchzoom/issues/128

Previously when there were multiple invocations of the `PinchZoom` constructor, a new `resize` event listener was registered each time. It led to the improper resing of the images when the users rotated their devices.

https://user-images.githubusercontent.com/68850090/180445251-7dd6962c-8ecc-4533-b303-420219356dae.mp4

But now developers can explicitly destroy the `PinchZoom` instance on unmount which will prevent redundant stacking of the event handlers and memory leaks